### PR TITLE
feat: add support for mongodb@6.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         node-version: [14.x, 16.x, 18.x]
         mongodb-version: ['4.0', '4.2', '4.4', '5.0', '6.0']
-        mongodb-lib: ['4.3.1', '^4.3.1', '5.0.0', '^5.0.0']
+        mongodb-lib: ['4.3.1', '^4.3.1', '5.0.0', '^5.0.0', '6.0.0', '^6.0.0']
 
     env:
       NODE: ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "mongodb": "^4.3.1 || ^5.0.0"
+    "mongodb": "^4.3.1 || ^5.0.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "@types/mongodb": {


### PR DESCRIPTION
This allow us to use the 6.x driver for mongo as it tries to make it backwards compatible.