### PR TITLE
chore: add test scenario for NodeJS 20.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         mongodb-version: ['4.0', '4.2', '4.4', '5.0', '6.0']
         mongodb-lib: ['5.7.0', '^5.7.0', '6.0.0', '^6.0.0']
 


### PR DESCRIPTION
This version [was active since 2023-11-22](https://nodejs.org/en/about/previous-releases), so we should have been validating that we are compatible with that since that date.
