### PR TITLE
fix: use node imports for builtin modules

### DIFF
--- a/src/mongodb-queue.ts
+++ b/src/mongodb-queue.ts
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import type { Db, Filter, UpdateFilter } from 'mongodb';
 
 // some helper functions


### PR DESCRIPTION
This will make it clear that the package comes from native node imports.