### PR TITLE
feat: 🔧 use rollup config with TS

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:ts": "tsc",
     "build": "concurrently 'npm:build:*'",
     "build:types": "tsc -p tsconfig.production.json",
-    "build:js": "rollup -c rollup.config.mjs",
+    "build:js": "rollup --config rollup.config.ts --configPlugin typescript --configImportAttributesKey with",
     "prepare": "concurrently 'npm:prepare:*'",
     "prepare:build": "npm run build",
     "prepare:husky": "husky install",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -2,22 +2,19 @@ import { babel } from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import builtinModules from 'builtin-modules';
+import type { RollupOptions } from 'rollup';
 import pkg from './package.json' with { type: 'json' };
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
 
-const config = {
+const config: RollupOptions = {
   strictDeprecations: true,
   input: 'src/mongodb-queue.ts',
 
   // Specify here external modules which you don't want to include in your
   // bundle (for instance: 'lodash', 'moment' etc.)
   // https://rollupjs.org/guide/en#external-e-external
-  external: [
-    ...builtinModules,
-    ...Object.keys(pkg.dependencies ?? {}),
-    ...Object.keys(pkg.peerDependencies ?? {}),
-  ],
+  external: [...builtinModules, ...Object.keys(pkg.peerDependencies ?? {})],
 
   plugins: [
     // Allows node_modules resolution

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "declarationDir": "dist/types",
     "declaration": true,
   },
-  "include": ["src/**/*", "rollup.config.mjs"],
+  "include": ["src/**/*", "rollup.config.ts"],
 }


### PR DESCRIPTION
The extra build configs should compatible across all NodeJS enviroments while making this config easier to maintain.